### PR TITLE
Add Advent of Code Progress Badges to README

### DIFF
--- a/.github/workflows/2019badges.yml
+++ b/.github/workflows/2019badges.yml
@@ -1,0 +1,34 @@
+name: Update AoC Badges
+on:
+  schedule:                                      # run workflow based on schedule
+    - cron: '6 5 1-25 12 *'                      # from the 1. December till 25. December every day at 5:06am (avoid load at full hours)
+    
+  workflow_dispatch:                             # allow to manually start the workflow 
+  
+# push:                                          # (disabled) run on push, be carefull with this setting 
+                                                 # as the workflow should only be triggered at a rate lower than
+                                                 # 4 times a hour to keep traffic on aoc site low 
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2                # clones your repo
+          
+      - uses: joblo2213/aoc-badges-action@v3
+        with:
+          userid: 656878                          # your user id, see setup on how to obtain
+          session: ${{ secrets.AOC_SESSION }}    # secret containing session code, see setup on how to obtain
+          
+#         Optional inputs:
+#         
+          year: 2019                                                                                     # The year for which stats should be retrieved
+#         leaderboard: 'https://adventofcode.com/2020/leaderboard/private/view/00000.json'               # The url of the leaderboard from witch the data is fetched. Typically your private leaderboard.
+          file: 'README.md'                                                                              # The file that contains the badges
+#         dayRegex: '(?<=https:\/\/img\.shields\.io\/badge\/day%20📅-)[0-9]+(?=-blue)'                   # Regular expression that finds the content of the day badge in your file.
+          starsRegex: '(?<=https:\/\/img\.shields\.io\/badge\/stars%20⭐-)[0-9]+(?=-yellow)'             # Regular expression that finds the content of the stars badge in your file.
+          daysCompletedRegex: '(?<=https:\/\/img\.shields\.io\/badge\/days%20completed-)[0-9]+(?=-red)'  # Regular expression that finds the content of the days completed badge iun your file.
+
+      - uses: stefanzweifel/git-auto-commit-action@v4     # Step that pushes these local changes back to your github repo
+        with:
+          commit_message: Update badges
+          file_pattern: README.md

--- a/.github/workflows/2020badges.yml
+++ b/.github/workflows/2020badges.yml
@@ -21,7 +21,7 @@ jobs:
           
 #         Optional inputs:
 #         
-          year: 2022                                                                                     # The year for which stats should be retrieved
+          year: 2020                                                                                     # The year for which stats should be retrieved
 #         leaderboard: 'https://adventofcode.com/2020/leaderboard/private/view/00000.json'               # The url of the leaderboard from witch the data is fetched. Typically your private leaderboard.
           file: 'README.md'                                                                              # The file that contains the badges
 #         dayRegex: '(?<=https:\/\/img\.shields\.io\/badge\/day%20📅-)[0-9]+(?=-blue)'                   # Regular expression that finds the content of the day badge in your file.

--- a/.github/workflows/2021badges.yml
+++ b/.github/workflows/2021badges.yml
@@ -1,0 +1,34 @@
+name: Update AoC Badges
+on:
+  schedule:                                      # run workflow based on schedule
+    - cron: '6 5 1-25 12 *'                      # from the 1. December till 25. December every day at 5:06am (avoid load at full hours)
+    
+  workflow_dispatch:                             # allow to manually start the workflow 
+  
+# push:                                          # (disabled) run on push, be carefull with this setting 
+                                                 # as the workflow should only be triggered at a rate lower than
+                                                 # 4 times a hour to keep traffic on aoc site low 
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2                # clones your repo
+          
+      - uses: joblo2213/aoc-badges-action@v3
+        with:
+          userid: 656878                          # your user id, see setup on how to obtain
+          session: ${{ secrets.AOC_SESSION }}    # secret containing session code, see setup on how to obtain
+          
+#         Optional inputs:
+#         
+          year: 2021                                                                                     # The year for which stats should be retrieved
+#         leaderboard: 'https://adventofcode.com/2020/leaderboard/private/view/00000.json'               # The url of the leaderboard from witch the data is fetched. Typically your private leaderboard.
+          file: 'README.md'                                                                              # The file that contains the badges
+#         dayRegex: '(?<=https:\/\/img\.shields\.io\/badge\/day%20📅-)[0-9]+(?=-blue)'                   # Regular expression that finds the content of the day badge in your file.
+          starsRegex: '(?<=https:\/\/img\.shields\.io\/badge\/stars%20⭐-)[0-9]+(?=-yellow)'             # Regular expression that finds the content of the stars badge in your file.
+          daysCompletedRegex: '(?<=https:\/\/img\.shields\.io\/badge\/days%20completed-)[0-9]+(?=-red)'  # Regular expression that finds the content of the days completed badge iun your file.
+
+      - uses: stefanzweifel/git-auto-commit-action@v4     # Step that pushes these local changes back to your github repo
+        with:
+          commit_message: Update badges
+          file_pattern: README.md

--- a/.github/workflows/2022badges.yml
+++ b/.github/workflows/2022badges.yml
@@ -1,0 +1,34 @@
+name: Update AoC Badges
+on:
+  schedule:                                      # run workflow based on schedule
+    - cron: '6 5 1-25 12 *'                      # from the 1. December till 25. December every day at 5:06am (avoid load at full hours)
+    
+  workflow_dispatch:                             # allow to manually start the workflow 
+  
+# push:                                          # (disabled) run on push, be carefull with this setting 
+                                                 # as the workflow should only be triggered at a rate lower than
+                                                 # 4 times a hour to keep traffic on aoc site low 
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2                # clones your repo
+          
+      - uses: joblo2213/aoc-badges-action@v3
+        with:
+          userid: 656878                          # your user id, see setup on how to obtain
+          session: ${{ secrets.AOC_SESSION }}    # secret containing session code, see setup on how to obtain
+          
+#         Optional inputs:
+#         
+          year: 2022                                                                                     # The year for which stats should be retrieved
+#         leaderboard: 'https://adventofcode.com/2020/leaderboard/private/view/00000.json'               # The url of the leaderboard from witch the data is fetched. Typically your private leaderboard.
+          file: 'README.md'                                                                              # The file that contains the badges
+#         dayRegex: '(?<=https:\/\/img\.shields\.io\/badge\/day%20📅-)[0-9]+(?=-blue)'                   # Regular expression that finds the content of the day badge in your file.
+          starsRegex: '(?<=https:\/\/img\.shields\.io\/badge\/stars%20⭐-)[0-9]+(?=-yellow)'             # Regular expression that finds the content of the stars badge in your file.
+          daysCompletedRegex: '(?<=https:\/\/img\.shields\.io\/badge\/days%20completed-)[0-9]+(?=-red)'  # Regular expression that finds the content of the days completed badge iun your file.
+
+      - uses: stefanzweifel/git-auto-commit-action@v4     # Step that pushes these local changes back to your github repo
+        with:
+          commit_message: Update badges
+          file_pattern: README.md

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,0 +1,34 @@
+name: Update AoC Badges
+on:
+  schedule:                                      # run workflow based on schedule
+    - cron: '6 5 1-25 12 *'                      # from the 1. December till 25. December every day at 5:06am (avoid load at full hours)
+    
+  workflow_dispatch:                             # allow to manually start the workflow 
+  
+# push:                                          # (disabled) run on push, be carefull with this setting 
+                                                 # as the workflow should only be triggered at a rate lower than
+                                                 # 4 times a hour to keep traffic on aoc site low 
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2                # clones your repo
+          
+      - uses: joblo2213/aoc-badges-action@v3
+        with:
+          userid: 656878                          # your user id, see setup on how to obtain
+          session: ${{ secrets.AOC_SESSION }}    # secret containing session code, see setup on how to obtain
+          
+#         Optional inputs:
+#         
+          year: 2022                                                                                     # The year for which stats should be retrieved
+#         leaderboard: 'https://adventofcode.com/2020/leaderboard/private/view/00000.json'               # The url of the leaderboard from witch the data is fetched. Typically your private leaderboard.
+          file: 'README.md'                                                                              # The file that contains the badges
+#         dayRegex: '(?<=https:\/\/img\.shields\.io\/badge\/day%20📅-)[0-9]+(?=-blue)'                   # Regular expression that finds the content of the day badge in your file.
+          starsRegex: '(?<=https:\/\/img\.shields\.io\/badge\/stars%20⭐-)[0-9]+(?=-yellow)'             # Regular expression that finds the content of the stars badge in your file.
+          daysCompletedRegex: '(?<=https:\/\/img\.shields\.io\/badge\/days%20completed-)[0-9]+(?=-red)'  # Regular expression that finds the content of the days completed badge iun your file.
+
+      - uses: stefanzweifel/git-auto-commit-action@v4     # Step that pushes these local changes back to your github repo
+        with:
+          commit_message: Update badges
+          file_pattern: README.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Advent of Code Solutions
+![2022](https://img.shields.io/badge/stars%20⭐-34-yellow)
+![2022](https://img.shields.io/badge/days%20completed-17-red)
 
 This repository contains my solutions for the Advent of Code (AoC) challenges, specifically for the year 2024. The structure is designed to organize inputs, solutions, and tests efficiently, facilitating quick access and understanding of each day's challenge.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Advent of Code Solutions
-![2022](https://img.shields.io/badge/stars%20⭐-34-yellow)
-![2022](https://img.shields.io/badge/days%20completed-17-red)
+| Year | Days Badge | Stars Badge |
+|------|------------|-------------|
+| 2019 | ![2019 Days](https://img.shields.io/badge/days%20completed-7-red) | ![2019 Stars](https://img.shields.io/badge/stars%20⭐-15-yellow) |
+| 2020 | ![2020 Days](https://img.shields.io/badge/days%20completed-10-red) | ![2020 Stars](https://img.shields.io/badge/stars%20⭐-22-yellow) |
+| 2021 | ![2021 Days](https://img.shields.io/badge/days%20completed-17-red) | ![2021 Stars](https://img.shields.io/badge/stars%20⭐-36-yellow) |
+| 2022 | ![2022 Days](https://img.shields.io/badge/days%20completed-14-red) | ![2022 Stars](https://img.shields.io/badge/stars%20⭐-28-yellow) |
+| 2023 | ![2023 Days](https://img.shields.io/badge/days%20completed-0-red) | ![2023 Stars](https://img.shields.io/badge/stars%20⭐-1-yellow) |
 
 This repository contains my solutions for the Advent of Code (AoC) challenges, specifically for the year 2024. The structure is designed to organize inputs, solutions, and tests efficiently, facilitating quick access and understanding of each day's challenge.
 


### PR DESCRIPTION
## Summary

This pull request introduces a series of updates to the `README.md` file, adding a new Markdown table that showcases the Advent of Code (AoC) progress across various years. It also includes the setup of separate GitHub Actions workflows dedicated to automatically updating the AoC badges for the years 2019 through 2022. These badges display the current day, total stars acquired, and the number of days completed for each specified year.

## Changes

- **README.md**: Added a new Markdown table displaying AoC progress badges for the years 2019 to 2023. This table includes badges for the total stars acquired and the number of days completed, offering a quick and visual representation of progress.
  
- **GitHub Actions Workflows**:
  - Added new workflows for the years 2019(`2019badges.yml`), 2020 (`2020badges.yml`), 2021 (`2021badges.yml`), and 2022 (`2022badges.yml`). Each workflow is tailored to update the AoC progress badges for its respective year.

## Rationale

Implementing these badges and workflows enhances the repository's README by providing a concise, at-a-glance view of the progress made by the Advent of Code over multiple years. It serves to both document achievements and motivate ongoing participation in the AoC challenges. Additionally, automating the badge updates through GitHub Actions ensures that the displayed information remains current with minimal manual intervention.

## Note

Please ensure that the AoC session secrets and user IDs are correctly configured within the repository's secrets to enable seamless updates by the GitHub Actions workflows.